### PR TITLE
$DESTDIR for ufo

### DIFF
--- a/bin/ufo
+++ b/bin/ufo
@@ -6,7 +6,7 @@ sub makefile_template() {
 .PHONY: all build test install clean distclean purge
 
 PERL6  = $binary
-DESTDIR= $ED
+DESTDIR= 
 PREFIX = $prefix
 BLIB   = blib
 P6LIB  = $(PWD)/$(BLIB)/lib:$(PWD)/lib:$(PERL6LIB)
@@ -57,13 +57,13 @@ sub MAIN($filename = 'Makefile', Bool :$alpha) {
     my $makefile = $filename eq '-' ?? $*OUT !! open $filename, :w;
     my $install_rules = join '', @modules>>.install-rule;
 	if $scripts {
-		$install_rules ~= "\t\$(MKDIR) \$(DESTDIR)$(PREFIX)/bin\n"
-						~ "\t\$(CP) \$(SCRIPTS) \$(DESTDIR)$(PREFIX)/bin\n";
+		$install_rules ~= "\t\$(MKDIR) \$(DESTDIR)\$(PREFIX)/bin\n"
+						~ "\t\$(CP) \$(SCRIPTS) \$(DESTDIR)\$(PREFIX)/bin\n";
 	}
     for @pods {
         my $dir         = .subst(rx{<-[/]>+$}, '');
-        $install_rules ~= "\t\$(MKDIR) \$(DESTDIR)$(PREFIX)/$dir\n";
-        $install_rules ~= "\t\$(CP) $_ \$(DESTDIR)$(PREFIX)/$dir\n";
+        $install_rules ~= "\t\$(MKDIR) \$(DESTDIR)\$(PREFIX)/$dir\n";
+        $install_rules ~= "\t\$(CP) $_ \$(DESTDIR)\$(PREFIX)/$dir\n";
     }
 
     $makefile.print(


### PR DESCRIPTION
formed makefile

``` makefile
.PHONY: all build test install clean distclean purge

PERL6  = perl6
DESTDIR= 
PREFIX = /usr/lib/parrot/5.1.0/languages/perl6/site
BLIB   = blib
P6LIB  = $(PWD)/$(BLIB)/lib:$(PWD)/lib:$(PERL6LIB)
CP     = cp -p
MKDIR  = mkdir -p

SCRIPTS= bin/ignore
BLIB_PIRS =

all build: $(BLIB_PIRS)



test: build
        env PERL6LIB=$(P6LIB) prove -e '$(PERL6)' -r t/

loudtest: build
        env PERL6LIB=$(P6LIB) prove -ve '$(PERL6)' -r t/

timetest: build
        env PERL6LIB=$(P6LIB) PERL6_TEST_TIMES=1 prove -ve '$(PERL6)' -r t/

install: $(BLIB_PIRS)
        $(MKDIR) $(DESTDIR)$(PREFIX)/bin
        $(CP) $(SCRIPTS) $(DESTDIR)$(PREFIX)/bin


clean:
        rm -fr $(BLIB)

distclean purge: clean
        rm -r Makefile
```
