### PR TITLE
Actually filter dirwalk entries

### DIFF
--- a/bin/ufo
+++ b/bin/ufo
@@ -221,7 +221,7 @@ sub find-file-by-ext(@dirs, *@ext) {
 sub dirwalk(Str $dir = '.', Mu :$d = none(<. ..>), Mu :$f = *, :&dx = -> $ {}, :&fx = -> $ {}) {
     for dir($dir) -> $p {
         when $p.f {
-            fx($p.Str)
+            fx($p.Str) if $p.Str ~~ $f;
         }
         when $p.d {
             dirwalk($p.Str, :$d, :$f, :&dx, :&fx)


### PR DESCRIPTION
We pass in a filter argument via `$f`, but it never gets used.
