### PR TITLE
Ufo crashes since repository rakudo  2014.05-128-gf146fec 

### DIFF
--- a/bin/ufo
+++ b/bin/ufo
@@ -158,7 +158,7 @@ sub get_prefix() {
 
 # blatantly stolen from Shell::Command
 sub mkpath($path) {
-    for [\~] $path.split('/').map({"$_/"}) {
+    for [\~] $path.Str.split('/').map({"$_/"}) {
         mkdir($_) unless .path.d
     }
 }


### PR DESCRIPTION
Since this commit https://github.com/rakudo/rakudo/commit/7d6acc7a0bea2a0588e77c70648655c9e947639d `CompUnitRepo::Local::Installation` is not a `Str`

I don't know whether this is temporary workaround or real fix but this change solves problem in my case.
